### PR TITLE
PROD-3549 Stop alert for Delayed Job

### DIFF
--- a/probes/delayed_job.rb
+++ b/probes/delayed_job.rb
@@ -23,7 +23,7 @@ if defined?(Delayed)
         record 'Delayed Job Backlog Age', true, 'No expired jobs'
       else
         diff = (now - value.run_at)
-        record 'Delayed Job Backlog Age', diff < 3600, "#{'%.1f' % (diff/60)} mins"
+        record 'Delayed Job Backlog Age', true, "#{'%.1f' % (diff/60)} mins"
       end
     end
 


### PR DESCRIPTION
[PROD-3549](https://cultureamp.atlassian.net/browse/PROD-3549)
## Approvals
- [x] lead / non-lead @sentience
- [ ] verified
## Description

When last Delayed Job takes more than an hour to run, do not alert.
This is usually just huge job taking more than an hour to finish.
